### PR TITLE
Using tagged 0.2.4 version of pdfextract

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/paperai/pdfanno#readme",
   "pdfextract": {
     "version": "0.2.4",
-    "url": "https://github.com/paperai/pdfextract/releases/download/untagged-6b0e4f23df695e8b7587/pdfextract-0.2.4.jar"
+    "url": "https://github.com/paperai/pdfextract/releases/download/v0.2.4/pdfextract-0.2.4.jar"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Replace the 404ing link with a new working one using a tagged release of pdfextract.

Test by removing `server/extlib/pdfextract-0.2.4.jar` and `server/server-data` . This should cause the pdftxt to regenerate and the jar to download.