### PR TITLE
Adding loading labels from url

### DIFF
--- a/server/controller/internal.js
+++ b/server/controller/internal.js
@@ -122,3 +122,35 @@ module.exports.loadAnno = function (req, res) {
         });
     });
 }
+
+/**
+ * Load an anno file from web.
+ *
+ * Examples:
+ *  - http://localhost:8080/dist/?pdf=http://www.yoheim.net/tmp/pdf-sample.pdf&anno=http://www.yoheim.net/tmp/ex1.anno
+ */
+module.exports.loadLabel = function (req, res) {
+
+    const labelURL = req.query.url;
+    console.log('labelURL=', labelURL);
+
+    const reqConfig = {
+        method : 'GET',
+        url    : labelURL
+    };
+    request(reqConfig, function(error, response, body) {
+        if (response.statusCode !== 200) {
+            if (response.statusCode === 404) {
+                error = 'Resource is not found.';
+            }
+            return res.json({
+                status : 'failure',
+                error  : error
+            });
+        }
+        res.json({
+            status : 'success',
+            label  : body
+        });
+    });
+}

--- a/server/server.js
+++ b/server/server.js
@@ -33,6 +33,9 @@ app.post('/internal/api/pdfs/:documentId', upload.fields([]), controller.interna
 app.get('/internal/api/pdfs', controller.internal.loadPDF)
 // Load an annotation from the web.
 app.get('/internal/api/annotations', controller.internal.loadAnno)
+// Load a label file from the web.
+app.get('/internal/api/labels', controller.internal.loadLabel)
+
 
 /***********************
  Internal APIs with DeepScholar.

--- a/server/service/index.js
+++ b/server/service/index.js
@@ -13,7 +13,6 @@ const packageJson = require('../../package.json')
 // const constants = require('../../src/shared/constants')
 const ANNO_FILE_EXTENSION = 'pdfanno'
 
-
 module.exports.deepscholarService = require('./deepscholar')
 
 module.exports.fetchPDF = async url => {

--- a/src/page/pdf/PDFAnnoPage.js
+++ b/src/page/pdf/PDFAnnoPage.js
@@ -621,6 +621,23 @@ export default class PDFAnnoPage {
     })
   }
 
+  /**
+   * Load a label file from the server.
+   */
+  loadLabelFileFromServer (url) {
+    return axios.get(`${window.API_ROOT}internal/api/labels?url=${url}`).then(res => {
+      if (res.status !== 200 || res.data.status === 'failure') {
+        let reason = ''
+        if (res.data.error) {
+          reason = '<br>Reason: ' + res.data.error
+        }
+        annoUI.ui.alertDialog.show({ message : 'Failed to load an label file. url=' + url + reason })
+        return Promise.reject()
+      }
+      return res.data.label
+    })
+  }
+
   set pdftxt (text) {
     this._pdftxt = text
   }

--- a/src/pdfanno.js
+++ b/src/pdfanno.js
@@ -103,11 +103,11 @@ async function displayViewer () {
   const q        = URI(document.URL).query(true)
   const pdfURL   = q.pdf || getDefaultPDFURL()
   const annoURL  = q.anno
+  const labelURL = q.label
   const moveTo   = q.move
 
   // Load a PDF file.
   try {
-
     let { pdf, analyzeResult } = await window.annoPage.loadPDFFromServer(pdfURL)
 
     setTimeout(() => {
@@ -119,6 +119,11 @@ async function displayViewer () {
 
     const listenPageRendered = async () => {
       showLoader(false)
+
+      if (labelURL) {
+        let label = await window.annoPage.loadLabelFileFromServer(labelURL)
+        annoUI.labelInput.loadLabelDbfromUrl(label)
+      }
 
       // Load and display annotations, if annoURL is set.
       if (annoURL) {


### PR DESCRIPTION
I added a feature to load labels with a label= url parameter, similar to how pdf= and anno= parameters work. This is something that I want, but I am not sure if you are interested in this feature. If you want this please let me know and I will cleanup the code a little bit and make it more presentable. There is a corresponding #[PR for anno-ui](https://github.com/paperai/anno-ui/pull/38) that makes the UI work.